### PR TITLE
Use config/blacklight.yml instead of config/solr.yml

### DIFF
--- a/lib/tasks/metastore-test_data.rake
+++ b/lib/tasks/metastore-test_data.rake
@@ -12,7 +12,7 @@ namespace :metastore do
 
     desc "Index fixtures"
     task :index => :environment do
-      $solr_config = YAML.load_file(Rails.root + 'config/solr.yml')[Rails.env]
+      $solr_config = YAML.load_file(Rails.root + 'config/blacklight.yml')[Rails.env]
 
       puts "Indexing"
       solr = RSolr.connect :url => $solr_config["url"]


### PR DESCRIPTION
 (for blacklight 6 compatibility)

You probably want to put this on a branch called something like uses_blacklight_yml until all of your gems are updated to have a blacklight.yml instead of a solr.yml -- you just need to rename the file, no changes necessary within the files.
